### PR TITLE
🎨 Palette: Improve accessibility and numeric input usability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-14 - Accessibility in Dynamic Component Frameworks
+**Learning:** In frameworks where UI components are generated dynamically (like SimpleUI), it's crucial to pass descriptive labels (e.g., `getVarName()`) to accessibility attributes like `contentDescription` for icon-only buttons. Generic labels are less helpful than context-aware ones.
+**Action:** Always check if dynamic components that use icons have access to a name or label that can be used for `contentDescription`.
+
+## 2025-05-14 - Numeric Input Flexibility
+**Learning:** When defining numeric input types in Android (`InputType`), omitting `TYPE_NUMBER_FLAG_SIGNED` can lead to poor UX where users are unable to enter negative values on many soft keyboards, even if the underlying data type (like `double`) supports it.
+**Action:** Ensure `TYPE_NUMBER_FLAG_SIGNED` is included for numeric inputs unless negative values are explicitly disallowed.

--- a/droidar/src/main/java/v2/simpleUi/M_Double.java
+++ b/droidar/src/main/java/v2/simpleUi/M_Double.java
@@ -59,7 +59,8 @@ public abstract class M_Double implements ModifierInterface, UiDecoratable {
 		e = new EditText(context);
 		e.setLayoutParams(p2);
 		e.setInputType(InputType.TYPE_CLASS_NUMBER
-				| InputType.TYPE_NUMBER_FLAG_DECIMAL);
+				| InputType.TYPE_NUMBER_FLAG_DECIMAL
+				| InputType.TYPE_NUMBER_FLAG_SIGNED);
 		e.setText("" + load());
 		e.setEnabled(editable);
 		e.setFocusable(editable);

--- a/droidar/src/main/java/v2/simpleUi/M_IconButtonWithText.java
+++ b/droidar/src/main/java/v2/simpleUi/M_IconButtonWithText.java
@@ -55,6 +55,9 @@ public abstract class M_IconButtonWithText implements ModifierInterface,
 			}
 		});
 		imageButton.setImageResource(myIconId);
+		if (myText != null) {
+			imageButton.setContentDescription(myText);
+		}
 		l.addView(imageButton);
 
 		TextView t = null;

--- a/droidar/src/main/java/v2/simpleUi/M_PlusMinus.java
+++ b/droidar/src/main/java/v2/simpleUi/M_PlusMinus.java
@@ -50,6 +50,7 @@ public abstract class M_PlusMinus implements ModifierInterface, UiDecoratable {
 		final ImageButton minusBtn = new ImageButton(context);
 		if (myMinusImageId != -1) {
 			minusBtn.setImageResource(myMinusImageId);
+			minusBtn.setContentDescription("Decrease " + getVarName());
 			minusBtn.setOnClickListener(new OnClickListener() {
 
 				@Override
@@ -76,6 +77,7 @@ public abstract class M_PlusMinus implements ModifierInterface, UiDecoratable {
 		final ImageButton plusBtn = new ImageButton(context);
 		if (myPlusImageId != -1) {
 			plusBtn.setImageResource(myPlusImageId);
+			plusBtn.setContentDescription("Increase " + getVarName());
 			plusBtn.setOnClickListener(new OnClickListener() {
 
 				@Override


### PR DESCRIPTION
This PR implements three micro-UX improvements that enhance accessibility and usability in the DroidAR framework's SimpleUI component library.

💡 What:
- Added `setContentDescription` to the `ImageView` in `M_IconButtonWithText`, using its text label.
- Added descriptive `setContentDescription` ("Increase [Name]" / "Decrease [Name]") to the `ImageButton`s in `M_PlusMinus`.
- Added the `TYPE_NUMBER_FLAG_SIGNED` flag to the numeric keyboard in `M_Double`.

🎯 Why:
- Icon buttons without content descriptions are inaccessible to screen reader users.
- The `M_Double` input was restricted to positive numbers on many soft keyboards, even though the data type supports negative values.

♿ Accessibility:
- Significantly improved screen reader support for several UI components by providing meaningful labels for icon-based interactive elements.

---
*PR created automatically by Jules for task [175654339386818903](https://jules.google.com/task/175654339386818903) started by @rafaisen*